### PR TITLE
Cast timestamp to string to avoid Zend error

### DIFF
--- a/code/GeocodingService.php
+++ b/code/GeocodingService.php
@@ -18,7 +18,7 @@ class GeocodingService implements IGeocodingService {
 	 * Marks as over daily limit
 	 */
 	protected function markLimit() {
-		$this->getCache()->save(time(), 'dailyLimit', array(), null);
+		$this->getCache()->save((string)time(), 'dailyLimit', array(), null);
 	}
 	
 	public function isOverLimit() {


### PR DESCRIPTION
`$data` parameter to `Zend_Cache_Core#save()` must be a string to avoid the `Datas must be string or set automatic_serialization = true` error
